### PR TITLE
Remove unnecessary permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ActivityRank Discord Bot
 A discord bot dedicated to Levels, XP, Rankings and Statistics. Sharded and capable of running distributed on multiple machines.
 
-[Live Bot Invite Link](https://discord.com/oauth2/authorize?client_id=534589798267224065&permissions=2114448593&scope=bot)
+[Live Bot Invite Link](https://discord.com/oauth2/authorize?client_id=534589798267224065&permissions=275884919872&scope=bot%20applications.commands)
 
 ## Other Repos
 

--- a/src/bot/events/interactionCreate.js
+++ b/src/bot/events/interactionCreate.js
@@ -1,27 +1,28 @@
 module.exports = {
 	name: 'interactionCreate',
 	async execute(interaction) {
-        if (interaction.isButton() || interaction.isSelectMenu())
-            await component(interaction);
-        if (interaction.isUserContextMenu())
-            await userCtx(interaction);
-
-        if (!interaction.isCommand()) return;
-
-        let path = "./commandsSlash";
-        path = path.concat("/", interaction.commandName)
-        const group = await interaction.options.getSubcommandGroup(false);
-        const sub = await interaction.options.getSubcommand(false);
-        if (group)
-            path = path.concat("/", group);
-        if (sub)
-            path = path.concat("/", sub);
-        path = path.concat(".js");
-        const command = interaction.client.commands.get(path);
-
-        if (!command) return;
-
         try {
+            if (interaction.isButton() || interaction.isSelectMenu())
+                await component(interaction);
+            if (interaction.isUserContextMenu())
+                await userCtx(interaction);
+
+            if (!interaction.isCommand()) return;
+
+            let path = "commandsSlash";
+            path = path.concat("/", interaction.commandName)
+            const group = await interaction.options.getSubcommandGroup(false);
+            const sub = await interaction.options.getSubcommand(false);
+            if (group)
+                path = path.concat("/", group);
+            if (sub)
+                path = path.concat("/", sub);
+            path = path.concat(".js");
+            const command = interaction.client.commands.get(path);
+
+            if (!command) return;
+
+
             await command.execute(interaction);
         } catch (e) {
             console.error(e);

--- a/src/bot/interactionDeployment/cmdLoader.js
+++ b/src/bot/interactionDeployment/cmdLoader.js
@@ -3,8 +3,6 @@ const path = require('path');
 const { Collection } = require('discord.js');
 const deployGlobal = require('./deploy-global.js')
 
-
-
 let files = [];
 
 function getRecursive(dir) {
@@ -18,7 +16,7 @@ function getRecursive(dir) {
 
 getRecursive(path.resolve(__dirname, '../commandsSlash'));
 
-files = files.map(fileName => fileName.replace(__dirname, '.'));
+files = files.map(fileName => fileName.replace(path.join(__dirname, '../'), ''));
 
 module.exports = (client) => {
 
@@ -28,7 +26,7 @@ module.exports = (client) => {
     client.commands = new Collection()
 
     files.forEach(fileName => {
-        const command = require(fileName);
+        const command = require(`../${fileName}`);
         client.commands.set(fileName, command);
     });
 

--- a/src/bot/util/checkBotPermissions.js
+++ b/src/bot/util/checkBotPermissions.js
@@ -8,9 +8,9 @@ const { botInviteLink } = require('../../const/config.js');
 
 let checkPermissionsCd;
 if (process.env.NODE_ENV == 'production') {
-  checkPermissionsCd = 3600 * 0.4;
+  checkPermissionsCd = 604800; // 1 week
 } else {
-  checkPermissionsCd = 3600 * 0.4; //20
+  checkPermissionsCd = 3600 * 0.4; //24 mins
 }
 
 

--- a/src/const/config.js
+++ b/src/const/config.js
@@ -1,5 +1,5 @@
 module.exports = {
   defaultPrefix: 'ar!',
   embedColor: '#4fd6c8',
-  botInviteLink: 'https://discord.com/api/oauth2/authorize?client_id=534589798267224065&permissions=294172224721&scope=bot%20applications.commands'
+  botInviteLink: 'https://discord.com/oauth2/authorize?client_id=534589798267224065&permissions=275884919872&scope=bot%20applications.commands'
 };


### PR DESCRIPTION
There have been lots of people complaining about perms in the help server, so hopefully these reviewed perms will work.

Included permissions:

Manage Roles
Change Own Nickname
Manage Nicknames
Manage Webhooks
Read Messages
Send Messages
Send Messages in Threads
Embed Links
Attach files
Read Message History
Use External Emojis
Add Reactions

Key permissions **not included**:

Create public/private threads
Manage Messages
Manage Threads
Use Voice Activity
Manage Server, Channels, or Emojis/stickers
Create Invite
